### PR TITLE
Implement basic search API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+pnpm-lock.yaml

--- a/app/api/[...path]/route.ts
+++ b/app/api/[...path]/route.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { exec, ExecException } from "child_process";
 import { marked } from "marked";
 import { NextRequest, NextResponse } from "next/server";
+import { buildIndex } from "@/services/search/searchService";
 
 // 커스텀 execAsync 함수 정의
 const execAsync = (
@@ -238,6 +239,9 @@ export async function POST(
     }
 
     await fs.writeFile(LAST_PULL_TIME_FILE, Date.now().toString());
+
+    // Update search index with new content
+    await buildIndex(OBSIDIAN_DIR);
 
     return NextResponse.json(
       { content: "Webhook processed and git pull executed successfully" },

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildIndex, search } from "@/services/search/searchService";
+
+export const dynamic = "force-dynamic";
+
+const OBSIDIAN_DIR = (process.env.REPO_PATH + "/Root") as string;
+
+let initialized = false;
+
+async function ensureIndex() {
+  if (!initialized) {
+    await buildIndex(OBSIDIAN_DIR);
+    initialized = true;
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const query = searchParams.get("q")?.trim();
+
+    if (!query) {
+      return NextResponse.json({ results: [] });
+    }
+
+    await ensureIndex();
+    const results = search(query);
+
+    return NextResponse.json({ results });
+  } catch (error) {
+    console.error("Search error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/services/search/searchService.ts
+++ b/services/search/searchService.ts
@@ -1,0 +1,47 @@
+import fs from "fs/promises";
+import path from "path";
+
+interface IndexEntry {
+  path: string;
+  title: string;
+  content: string;
+}
+
+let index: IndexEntry[] = [];
+
+async function walk(dir: string) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      const content = await fs.readFile(fullPath, "utf8");
+      const titleMatch = content.match(/^#\s+(.*)/m);
+      const title = titleMatch ? titleMatch[1].trim() : entry.name.replace(/\.md$/, "");
+      index.push({ path: fullPath, title, content });
+    }
+  }
+}
+
+export async function buildIndex(baseDir: string): Promise<void> {
+  index = [];
+  await walk(baseDir);
+}
+
+export function search(query: string): Array<{ path: string; title: string; snippet: string }> {
+  const lower = query.toLowerCase();
+  return index
+    .filter((doc) => doc.content.toLowerCase().includes(lower) || doc.title.toLowerCase().includes(lower))
+    .map((doc) => {
+      const pos = doc.content.toLowerCase().indexOf(lower);
+      let snippet = "";
+      if (pos !== -1) {
+        const start = Math.max(0, pos - 30);
+        const end = Math.min(doc.content.length, pos + lower.length + 30);
+        snippet = doc.content.slice(start, end).replace(/\n/g, " ");
+      }
+      const relative = doc.path.split("Root")[1].replace(/^\//, "");
+      return { path: `/${relative}`, title: doc.title, snippet };
+    });
+}


### PR DESCRIPTION
## Summary
- add simple Markdown indexing service
- provide GET `/api/search` to query the index
- refresh index when webhook pulls new content
- ignore pnpm lockfile

## Testing
- `npm run lint`
- `npm run build` *(fails: Argument of type 'Window' is not assignable to parameter of type 'WindowLike')*

------
https://chatgpt.com/codex/tasks/task_e_68591ca588748330be83df9f7c3c6bf7