### PR TITLE
Add configurable site metadata

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -2,6 +2,11 @@
 NODE_ENV=
 SERVER_DOMAIN=
 
+# 사이트 기본 정보
+SITE_NAME=
+SITE_URL=
+SITE_AUTHOR=
+
 # 관리자의 이메일 주소
 NEXT_PUBLIC_ADMIN_EMAIL=
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
    ```bash
    npm install
    ```
-2. `.env_sample`을 `.env`로 복사한 뒤 `SERVER_DOMAIN`, `REPO_PATH`, Firebase 키, `GITHUB_WEBHOOK_SECRET` 등 필요한 값을 입력합니다.
+2. `.env_sample`을 `.env`로 복사한 뒤 `SERVER_DOMAIN`, `REPO_PATH`, Firebase 키,
+   `GITHUB_WEBHOOK_SECRET`, `SITE_NAME`, `SITE_URL`, `SITE_AUTHOR` 등 필요한 값을 입력합니다.
 3. 개발 서버 실행
    ```bash
    npm run dev
@@ -40,6 +41,6 @@ npm run start
 - `app/` – Next.js 라우트, 컴포넌트와 유틸리티
 - `services/` – 서버 사이드 서비스 함수들
 - `public/` – 정적 자산
-- `.env_sample` – 환경 변수 예시 파일
+- `.env_sample` – 환경 변수 예시 파일 (`SITE_NAME`, `SITE_URL`, `SITE_AUTHOR` 등)
 
 노트는 `REPO_PATH/Root`에서 읽어와 페이지로 제공합니다. GitHub에서 `push` 웹훅이 오면 API가 `git pull`을 실행해 최신 내용을 반영합니다.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,20 +3,24 @@ import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 
+const siteName = process.env.SITE_NAME || "DooWiki";
+const siteUrl = process.env.SITE_URL || "https://doowiki.site";
+const siteAuthor = process.env.SITE_AUTHOR || "DooDeveloper";
+
 export const metadata: Metadata = {
   title: {
-    default: "DooWiki",
-    template: "%s | DooWiki",
+    default: siteName,
+    template: `%s | ${siteName}`,
   },
-  description: "DooWiki - Dooveloper Wiki",
+  description: `${siteName} - ${siteAuthor} Wiki`,
   keywords: ["DooWiki", "Dooveloper", "Wiki", "Frontend", "React", "Next.js"],
-  authors: [{ name: "DooDeveloper", url: "https://doowiki.site" }],
+  authors: [{ name: siteAuthor, url: siteUrl }],
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://doowiki.site",
-    title: "DooWiki - Dooveloper Wiki",
-    description: "DooWiki - Dooveloper Wiki",
+    url: siteUrl,
+    title: `${siteName} - ${siteAuthor} Wiki`,
+    description: `${siteName} - ${siteAuthor} Wiki`,
     images: ["/og-image.png"],
   },
 };


### PR DESCRIPTION
## Summary
- allow customizing site metadata via env vars
- read SITE_NAME, SITE_URL and SITE_AUTHOR in layout
- document new env vars

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686128c168a08330b9a0d7cb32a700c0