### PR TITLE
Add OBSIDIAN_ROOT_DIR env support

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -12,6 +12,7 @@ NEXT_PUBLIC_ADMIN_EMAIL=
 
 # Obsidian 경로를 설정
 REPO_PATH=
+OBSIDIAN_ROOT_DIR=Root
 
 # Firebase 관련 key 설정
 NEXT_PUBLIC_FIREBASE_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 pnpm-lock.yaml
+\ndist

--- a/app/api/[...path]/route.ts
+++ b/app/api/[...path]/route.ts
@@ -35,8 +35,9 @@ marked.setOptions({
   breaks: true, // 줄바꿈 시 <br> 태그를 추가하도록 설정
 });
 
-const OBSIDIAN_DIR = (process.env.REPO_PATH + "/Root") as string;
-const OBSIDIAN_LINK_REGEX = /\[([^\]]+)\]\(Root/g;
+const ROOT_DIR = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+const OBSIDIAN_DIR = (process.env.REPO_PATH + `/${ROOT_DIR}`) as string;
+const OBSIDIAN_LINK_REGEX = new RegExp(`\\[([^\\]]+)\\]\\(${ROOT_DIR}`, 'g');
 const OBSIDIAN_INDEX_REGEX = /\[\[([^\|]+)\|([^\]]+)\]\]/g;
 
 const REMARK_REGEX = /%%[^%]+%%/g;
@@ -60,7 +61,7 @@ interface ApiResponse {
 const convertObsidianIndexLinks = (content: string): string => {
   return content.replace(OBSIDIAN_INDEX_REGEX, (_, link, text) => {
     const formattedLink = link.replace(/ /g, "%20");
-    const removeRoot = formattedLink.replace("Root/", "");
+    const removeRoot = formattedLink.replace(`${ROOT_DIR}/`, "");
     return `[${text}](/${removeRoot}.md)`;
   });
 };

--- a/app/api/current-directory/route.ts
+++ b/app/api/current-directory/route.ts
@@ -19,7 +19,8 @@ export async function GET(request: NextRequest) {
     const currentPath = searchParams.get('path') || '';
     
     const repoPath = process.env.REPO_PATH || '';
-    const rootDir = path.join(repoPath, 'Root');
+    const rootDirName = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+    const rootDir = path.join(repoPath, rootDirName);
     
     if (!repoPath || !fs.existsSync(rootDir)) {
       return NextResponse.json({ error: 'Root directory not found' }, { status: 404 });
@@ -33,7 +34,7 @@ export async function GET(request: NextRequest) {
     let directoryToScan = rootDir;
     let relativePath = '';
     
-    if (currentPath && currentPath !== '/' && currentPath !== '_Index_of_Root.md') {
+    if (currentPath && currentPath !== '/' && currentPath !== `_Index_of_${rootDirName}.md`) {
       // Clean the path - remove leading slash and decode URL
       const cleanPath = decodeURIComponent(currentPath.startsWith('/') ? currentPath.slice(1) : currentPath);
       
@@ -106,7 +107,7 @@ export async function GET(request: NextRequest) {
     
     return NextResponse.json({ 
       items,
-      currentPath: relativePath || 'Root',
+      currentPath: relativePath || rootDirName,
       totalCount: items.length
     });
   } catch (error) {

--- a/app/api/popular-posts/route.ts
+++ b/app/api/popular-posts/route.ts
@@ -39,8 +39,9 @@ export async function GET(request: NextRequest) {
         let path = linkMatch[2];
         
         // Remove "Root/" prefix if present
-        if (path.startsWith('Root/')) {
-          path = path.substring(5);
+        const rootDirName = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+        if (path.startsWith(`${rootDirName}/`)) {
+          path = path.substring(rootDirName.length + 1);
         }
         
         // Add leading slash if not present

--- a/app/api/recent-posts/route.ts
+++ b/app/api/recent-posts/route.ts
@@ -83,8 +83,9 @@ export async function GET(request: NextRequest) {
     }
 
     const repoPath = getEnvVar('REPO_PATH');
-    // Ensure we only scan within the Root directory for security
-    const rootDir = path.join(repoPath, 'Root');
+    const rootDirName = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+    // Ensure we only scan within the root directory for security
+    const rootDir = path.join(repoPath, rootDirName);
     
     if (!fs.existsSync(rootDir)) {
       return createErrorResponse('Root directory not found', 404);

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -4,7 +4,8 @@ import { getCurrentUser } from "@/app/lib/utils";
 
 export const dynamic = "force-dynamic";
 
-const OBSIDIAN_DIR = (process.env.REPO_PATH + "/Root") as string;
+const ROOT_DIR = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+const OBSIDIAN_DIR = (process.env.REPO_PATH + `/${ROOT_DIR}`) as string;
 
 let initialized = false;
 

--- a/app/components/Breadcrumbs.tsx
+++ b/app/components/Breadcrumbs.tsx
@@ -17,9 +17,10 @@ export default function Breadcrumbs() {
 
   const isIndexFile = last?.startsWith('_Index_of_')
 
+  const ROOT_DIR = process.env.OBSIDIAN_ROOT_DIR || 'Root'
   if (isIndexFile) {
     // 루트 인덱스라면 브래드크럼을 표시하지 않음
-    if (last === '_Index_of_Root.md') {
+    if (last === `_Index_of_${ROOT_DIR}.md`) {
       return null
     }
     // 인덱스 파일 세그먼트 제거

--- a/app/lib/env-validation.ts
+++ b/app/lib/env-validation.ts
@@ -1,6 +1,7 @@
 // Environment variable validation
 const requiredEnvVars = [
   'REPO_PATH',
+  'OBSIDIAN_ROOT_DIR',
 ] as const;
 
 // Optional env vars for future use
@@ -33,10 +34,23 @@ export function validateEnvironment(): void {
     });
   }
 
+  const rootDir = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+  if (repoPath) {
+    const fullRootPath = require('path').join(repoPath, rootDir);
+    import('fs').then(fs => {
+      if (!fs.existsSync(fullRootPath)) {
+        console.warn(`Warning: OBSIDIAN_ROOT_DIR does not exist: ${fullRootPath}`);
+      }
+    }).catch(() => {
+      console.warn('Could not validate OBSIDIAN_ROOT_DIR existence');
+    });
+  }
+
   // Log environment status in development
   if (process.env.NODE_ENV === 'development') {
     console.log('✅ Environment variables validated successfully');
     console.log(`📁 REPO_PATH: ${process.env.REPO_PATH}`);
+    console.log(`📂 OBSIDIAN_ROOT_DIR: ${process.env.OBSIDIAN_ROOT_DIR}`);
     console.log(`🌐 API_URL: ${process.env.NEXT_PUBLIC_API_URL || 'not set'}`);
   }
 }

--- a/app/lib/obsidian/content-processor.ts
+++ b/app/lib/obsidian/content-processor.ts
@@ -31,6 +31,7 @@ export function isIndexPage(path: string): boolean {
   );
 }
 
+const ROOT_DIR = process.env.OBSIDIAN_ROOT_DIR || 'Root';
 export function isRootPath(path: string): boolean {
-  return path === "_Index_of_Root.md";
+  return path === `_Index_of_${ROOT_DIR}.md`;
 }

--- a/app/lib/obsidian/parser.ts
+++ b/app/lib/obsidian/parser.ts
@@ -185,7 +185,8 @@ function handleParagraphElement(
     }> => React.isValidElement(child) && !!child.props["data-href"]
   );
 
-  const isRoot = path === "_Index_of_Root.md";
+  const ROOT_DIR = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+  const isRoot = path === `_Index_of_${ROOT_DIR}.md`;
 
   let directories = links.filter((link) => link.props["data-is-directory"] === "true");
   let files = links.filter((link) => link.props["data-is-directory"] === "false");

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -22,7 +22,7 @@ export const hasPermission = (
   
   // Remove common prefixes that might interfere with pattern matching
   const cleanPath = decodedPath
-    .replace(/^\/Root\//, '/') // Remove /Root/ prefix
+    .replace(new RegExp(`^/${process.env.OBSIDIAN_ROOT_DIR || 'Root'}/`), '/') // Remove /Root/ prefix
     .replace(/\/_Index_of_/, '/') // Normalize index paths
     .replace(/\.md$/, ''); // Remove .md extension
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+const ROOT_DIR = process.env.OBSIDIAN_ROOT_DIR || 'Root';
 export default function Home() {
-  redirect("/_Index_of_Root.md");
+  redirect(`/_Index_of_${ROOT_DIR}.md`);
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,7 +4,8 @@ import path from 'path'
 import { pagePermissions } from './types/pagePermissions'
 import { getHost } from './lib/utils'  // getHost import 추가
 
-const OBSIDIAN_DIR = (process.env.REPO_PATH + "/Root") as string;
+const ROOT_DIR = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+const OBSIDIAN_DIR = (process.env.REPO_PATH + `/${ROOT_DIR}`) as string;
 const DAILY_FREQUENCY = 'daily' as const;
 const baseUrl = getHost() as string;
 
@@ -58,7 +59,7 @@ async function getAllFilePaths(dir: string, baseDir: string = dir): Promise<stri
             .join('/');
           
           // _Index_of_ 파일 처리 수정
-          if (entry.name === '_Index_of_Root.md' || !entry.name.includes('_Index_of_')) {
+          if (entry.name === `_Index_of_${ROOT_DIR}.md` || !entry.name.includes('_Index_of_')) {
             if (isPathPublic(relativePath)) {
               return relativePath;
             }

--- a/app/types/pagePermissions.ts
+++ b/app/types/pagePermissions.ts
@@ -22,7 +22,7 @@ export const pagePermissions: PagePermission[] = [
     isPublic: true,
   },
   {
-    path: '/_Index_of_Root*',
+    path: `/_Index_of_${process.env.OBSIDIAN_ROOT_DIR || 'Root'}*`,
     allowedRoles: [],
     isPublic: true,
   },
@@ -88,4 +88,4 @@ export const pagePermissions: PagePermission[] = [
   // },
 ];
 
-export const isPublicPageList = ['/', '/login*', '/_Index_of_Root*', '/unauthorized'];
+export const isPublicPageList = ['/', '/login*', `/_Index_of_${process.env.OBSIDIAN_ROOT_DIR || 'Root'}*`, '/unauthorized'];

--- a/app/utils/pathUtils.ts
+++ b/app/utils/pathUtils.ts
@@ -1,12 +1,14 @@
+const ROOT_DIR_NAME = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+
 export function getCurrentLocationInfo(pathname: string | null) {
-  if (!pathname) return { type: "directory", name: "Root", parentPath: "" };
+  if (!pathname) return { type: "directory", name: ROOT_DIR_NAME, parentPath: "" };
 
   const currentPath = decodeURIComponent(
     pathname.startsWith("/") ? pathname.slice(1) : pathname
   );
 
-  if (!currentPath || currentPath === "_Index_of_Root.md") {
-    return { type: "directory", name: "Root", parentPath: "" };
+  if (!currentPath || currentPath === `_Index_of_${ROOT_DIR_NAME}.md`) {
+    return { type: "directory", name: ROOT_DIR_NAME, parentPath: "" };
   }
 
   // Extract information from path
@@ -41,7 +43,7 @@ export function getBreadcrumbs(pathname: string | null) {
   const currentPath = decodeURIComponent(pathname.startsWith('/') ? pathname.slice(1) : pathname);
   
   // If we're at root, return empty breadcrumbs
-  if (!currentPath || currentPath === '_Index_of_Root.md') {
+  if (!currentPath || currentPath === `_Index_of_${ROOT_DIR_NAME}.md`) {
     return [];
   }
   
@@ -49,8 +51,8 @@ export function getBreadcrumbs(pathname: string | null) {
   
   // Always add root link
   breadcrumbs.push({
-    name: "🏠 Root",
-    path: "/_Index_of_Root.md"
+    name: `🏠 ${ROOT_DIR_NAME}`,
+    path: `/_Index_of_${ROOT_DIR_NAME}.md`
   });
   
   // Parse the current path to build breadcrumbs

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 33000",
     "build": "next build",
     "start": "next start -p 33000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "npx tsc --outDir dist --noEmit false && node --test tests"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.15",

--- a/services/search/searchService.ts
+++ b/services/search/searchService.ts
@@ -52,7 +52,8 @@ export function search(
         const end = Math.min(doc.content.length, pos + lower.length + 30);
         snippet = doc.content.slice(start, end).replace(/\n/g, " ");
       }
-      const relative = doc.path.split("Root")[1].replace(/^\//, "");
+      const rootDirName = process.env.OBSIDIAN_ROOT_DIR || 'Root';
+      const relative = doc.path.split(rootDirName)[1].replace(/^\//, "");
       return { path: `/${relative}`, title: doc.title, snippet };
     })
     .filter((result) => hasPermission(userRole, result.path));

--- a/tests/customRoot.test.js
+++ b/tests/customRoot.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Test path utils with custom root directory
+
+test('path utilities handle custom root directory', async () => {
+  process.env.OBSIDIAN_ROOT_DIR = 'Custom';
+  const utils = await import('../dist/app/utils/pathUtils.js');
+  const info = utils.getCurrentLocationInfo(null);
+  assert.strictEqual(info.name, 'Custom');
+});
+


### PR DESCRIPTION
## Summary
- introduce `OBSIDIAN_ROOT_DIR` environment variable
- use new variable across API routes, utils, and sitemap
- validate new env var
- add a basic test for custom root folder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686129b5c9a88330b8bc35facc830a25